### PR TITLE
correct a linkedin link

### DIFF
--- a/index.html
+++ b/index.html
@@ -722,7 +722,7 @@
 											<a href="https://github.com/"><i class="icon fa fa-github"></i></a>
 											<a href="https://www.facebook.com/"><i class="icon social_facebook"></i></a>
 											<a href="https://twitter.com/" target="_self"><i class="icon social_twitter"></i></a>
-											<a href="https://www.linkedin.com/in/dishantkhanna" target="_self"><i class="icon social_linkedin"></i></a>
+											<a href="https://www.linkedin.com" target="_self"><i class="icon social_linkedin"></i></a>
 										</div>
 									</div>
 								</div>


### PR DESCRIPTION
The linkedin link that is given under Agata's profile is actually that of dishant's. So removed the link and put a placeholder link to linkedin's website instead.