### PR TITLE
Fix the alignment of text-links in the projects section

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
 										<ul class="nav-dropdown">
 											<li><a href="http://2016.codeheat.org" target="_self">Codeheat 2016</a></li>
 											<li><a href="http://2017.codeheat.org" target="_self">Codeheat 2017</a></li>
-										</ul>							
+										</ul>
 									</li>
 									<li><a class="inner-link" href="#timeline" target="_self">Timeline</a></li>
 									<li><a class="inner-link" href="#jury" target="_self">Jury</a></li>
@@ -252,7 +252,7 @@
 										<a href="https://groups.google.com/group/open-event" target="_self">Mailing List</a>
 										<a href="https://github.com/fossasia?utf8=✓&q=open-event" target="_self">Repositories</a>
 										<a href="https://play.google.com/store/apps/details?id=org.fossasia.eventyay" target="_self">Android App</a>
-										<a href="https://play.google.com/store/apps/details?id=org.fossasia.openevent" target="_self">FOSSASIA Summit'17 App</a>										
+										<a href="https://play.google.com/store/apps/details?id=org.fossasia.openevent" target="_self">FOSSASIA Summit'17 App</a>
 									</div>
 								</div>
 							</div>
@@ -283,7 +283,7 @@
 										<a href="http://groups.google.com/group/loklak/" target="_self">Mailing List</a>
 										<a href="https://github.com/fossasia?utf8=%E2%9C%93&q=loklak" target="_self">Front-end Repositories</a>
 										<a href="https://github.com/loklak/" target="_self">Backend Repositories</a>
-										<a href="https://play.google.com/store/apps/details?id=org.loklak.android.wok" target="_self">Android App</a> 
+										<a href="https://play.google.com/store/apps/details?id=org.loklak.android.wok" target="_self">Android App</a>
 										<br><br>
 									</div>
 								</div>
@@ -317,77 +317,77 @@
 										<a href="https://play.google.com/store/apps/details?id=org.fossasia.pslab" target="_self">Android App</a>
 									</div>
 								</div>
-							</div>							
+							</div>
 
 							<div class="col-md-4 col-sm-6">
 								<div class="info-box">
 									<img alt="Meilix" src="img/meilix.jpg">
 									<h3>Meilix</h3>
 									<p>Meilix is a beautiful Linux distribution based on Debian and lubuntu using LXQT and other lightweight applications. With the Meilix generator users can generate their own customized Meilix version for events, kiosk systems or home use.</p><div><br></div><div><br><br></div>
-									<div class="text-link">
+									<div class="text-link" style="margin-right: 15%">
 										<a href="https://meilix.fossasia.org" target="_self">Website</a>
 										<a href="https://gitter.im/fossasaia/meilix" target="_self">Chat</a>
 										<a href="http://groups.google.com/group/meilix/" target="_self">Mailing List</a>
 										<a href="https://github.com/fossasia?utf8=✓&q=meilix" target="_self">Repositories</a>
 									</div>
 								</div>
-							</div>	
+							</div>
 
 							<div class="col-md-4 col-sm-6">
 								<div class="info-box">
 									<img alt="Susper Search" src="img/susper.png">
 									<h3>Susper Search</h3>
 									<p>Susper is a distributed Peer to Peer search engine using Yacy and Elastic Search. The front-end uses Angular JS and Material design.</p><div><br></div><div><br></div>
-									<div class="text-link">
+									<div class="text-link" style="margin-right: 15%">
 										<a href="http://susper.com" target="_self">Website</a>
 										<a href="https://gitter.im/fossasaia/susper.com" target="_self">Chat</a>
 										<a href="https://groups.google.com/forum/#!forum/opntec-dev" target="_self">Mailing List</a>
 										<a href="https://github.com/fossasia/susper.com" target="_self">Repository</a>
 									</div>
 								</div>
-							</div>	
+							</div>
 
 							<div class="col-md-4 col-sm-6">
 								<div class="info-box">
 									<img alt="Yaydoc" src="img/yaydoc.png">
 									<h3>Yaydoc</h3>
 									<p>Yaydoc is a documentation generator for Git and GitHub projects generating a complete website with search capabilities and automatic deployment on each merged pull request.</p><div><br></div><div><br></div>
-									<div class="text-link">
+									<div class="text-link" style="margin-right: 15%">
 										<a href="http://yaydoc.org" target="_self">Website</a>
 										<a href="https://gitter.im/fossasaia/yaydoc" target="_self">Chat</a>
 										<a href="http://groups.google.com/group/yaydoc/" target="_self">Mailing List</a>
 										<a href="https://github.com/fossasia/yaydoc" target="_self">Repository</a>
 									</div>
 								</div>
-							</div>	
+							</div>
 
 							<div class="col-md-4 col-sm-6">
 								<div class="info-box">
 									<img alt="Query Server" src="img/query-server.jpg">
 									<h3>Query Server</h3>
 									<p>The query server can be used to search a keyword/phrase on a search engine (Google, Yahoo, Bing, DuckDuckGo) and get the results as json or xml. The tool also stores the searched query string in a MongoDB database for analytical purposes.</p><div><br></div><div><br></div>
-									<div class="text-link">
+									<div class="text-link" style="margin-right: 15%">
 										<a href="https://query-server.herokuapp.com" target="_self">Website</a>
 										<a href="https://gitter.im/fossasia/query-server" target="_self">Chat</a>
 										<a href="http://groups.google.com/group/opntec-dev/" target="_self">Mailing List</a>
 										<a href="https://github.com/fossasia/query-server" target="_self">Repository</a>
 									</div>
 								</div>
-							</div>	
+							</div>
 
 							<div class="col-md-4 col-sm-6">
 								<div class="info-box">
 									<img alt="FOSSASIA Labs" src="img/fossasialabs.png">
 									<h3>FOSSASIA Labs</h3>
 									<p>FOSSASIA Labs provides a starting point for developers interested in new projects and additional components to existing projects. The issue tracker holds a number of project ideas to get started.</p><div><br></div><div><br></div>
-									<div class="text-link">
+									<div class="text-link" style="margin-right: 15%">
 										<a href="http://labs.fossasia.org" target="_self">Website</a>
 										<a href="https://gitter.im/fossasaia/fossasia" target="_self">Chat</a>
 										<a href="http://groups.google.com/group/opntec-dev/" target="_self">Mailing List</a>
 										<a href="https://github.com/fossasia/labs.fossasia.org" target="_self">Repository</a>
 									</div>
 								</div>
-							</div>	
+							</div>
 
 							<div class="col-md-4 col-sm-6">
 								<div class="info-box">
@@ -395,26 +395,26 @@
 									<h3>SUSI.AI for Magic Mirror</h3>
 									<p>SUSI.AI modules for Magic Mirror.
 									Apart from the SUSI.AI core repositories in this project we integrate SUSI.AI into the Magic Mirror project. Join us developing the magic mirror!</p><div><br></div><div><br></div>
-									<div class="text-link">
+									<div class="text-link" style="margin-right: 31%">
 										<a href="https://gitter.im/fossasaia/susi_server" target="_self">Chat</a>
 										<a href="http://groups.google.com/group/susiai/" target="_self">Mailing List</a>
 										<a href="https://github.com/fossasia/MMM-SUSI-AI" target="_self">Repository</a>
 									</div>
 								</div>
-							</div>	
+							</div>
 
 							<div class="col-md-4 col-sm-6">
 								<div class="info-box">
 									<img alt="FOSSASIA Labs" src="img/badgeyay.jpg">
 									<h3>Badgeyay</h3>
 									<p>At every event the same question comes up "how to print out badges". There are a number of proprietary websites out there, by why not create our own automatic badge generator for events?</p><div><br></div><div><br></div>
-									<div class="text-link">
+									<div class="text-link" style="margin-right: 31%">
 										<a href="https://gitter.im/fossasaia/open-event-orga-server" target="_self">Chat</a>
 										<a href="http://groups.google.com/group/open-event/" target="_self">Mailing List</a>
 										<a href="https://github.com/fossasia/badgeyay" target="_self">Repository</a>
 									</div>
 								</div>
-							</div>	
+							</div>
 
 						</div>
 					</div>
@@ -1031,7 +1031,7 @@
 										<div class="middle"></div>
 										<div class="bottom"></div>
 									</div>
-								</li>								
+								</li>
 
 								<li>
 									<div class="schedule-title">
@@ -1126,7 +1126,7 @@
 										<div class="middle"></div>
 										<div class="bottom"></div>
 									</div>
-								</li>								
+								</li>
 
 								<li>
 									<div class="schedule-title">
@@ -1300,7 +1300,7 @@
 								* Support of high-school students in the Google Code-In program<br>
 								* Create two screencasts or videos about the project you are working on for the FOSSASIA YouTube channel (a) before November 1, 2017 and (b) before February 2018 (You will receive access to the FOSSASIA Youtube)<br>
 								* Make a project presentation with Google docs by January 31, 2018<br>
-								* Create a Gist with a list of the work outcome by January 31, 2018<br>				
+								* Create a Gist with a list of the work outcome by January 31, 2018<br>
 								</p>
 							</div>
 						</div>
@@ -1369,7 +1369,7 @@
 								* Participate in chats on the project channels<br>
 								* Provide continuous updates in weekly scrums, monthly blog posts
 								* Create two screencasts and a presentation
-								* Provide a Gist with a list of the work outcome of your work by January 31, 2018<br>	
+								* Provide a Gist with a list of the work outcome of your work by January 31, 2018<br>
 								</p>
 							</div>
 						</div>


### PR DESCRIPTION
The text-links that were aligned to the right have been moved to the center. 
Here is the Screenshot :

![screen shot 2017-09-06 at 9 38 53 pm](https://user-images.githubusercontent.com/22046387/30122401-f4a22648-934b-11e7-8639-9ac5d881bb77.png)
