### PR TITLE
Change nav-bar breakpoint

### DIFF
--- a/css/theme-sulphur.css
+++ b/css/theme-sulphur.css
@@ -751,7 +751,7 @@ nav .container {
   margin-bottom: 32px;
   left: 24px;
 }
-@media all and (max-width: 768px) {
+@media all and (max-width: 968px) {
   nav {
     max-height: 67px;
     overflow: hidden;


### PR DESCRIPTION
Fix issue : #44 
I've just changed the media query for the nav-bar to 968. So that the the contents don't overlap with "codeheat".