### PR TITLE
Solved a typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,3 @@
-
 <!doctype html>
 <html lang="en">
     <head>
@@ -296,7 +295,7 @@
 									<p>Phimp.me is an image applications for Android that does not miss out on features. Help to make the app more stable and support more social accounts in the app.</p><div><br></div><div><br><br></div>
 									<div class="text-link">
 										<a href="https://phimp.me" target="_self">Website</a>
-										<a href="https://gitter.im/fossasaia/phimpme" target="_self">Chat</a>
+										<a href="https://gitter.im/fossasia/phimpme" target="_self">Chat</a>
 										<a href="http://groups.google.com/group/phimpme/" target="_self">Mailing List</a>
 										<a href="https://github.com/fossasia/phimpme-android" target="_self">Repository</a>
 										<a href="https://play.google.com/store/apps/details?id=org.fossasia.phimpme" target="_self">Organizer Android App</a>
@@ -326,7 +325,7 @@
 									<p>Meilix is a beautiful Linux distribution based on Debian and lubuntu using LXQT and other lightweight applications. With the Meilix generator users can generate their own customized Meilix version for events, kiosk systems or home use.</p><div><br></div><div><br><br></div>
 									<div class="text-link" style="margin-right: 15%">
 										<a href="https://meilix.fossasia.org" target="_self">Website</a>
-										<a href="https://gitter.im/fossasaia/meilix" target="_self">Chat</a>
+										<a href="https://gitter.im/fossasia/meilix" target="_self">Chat</a>
 										<a href="http://groups.google.com/group/meilix/" target="_self">Mailing List</a>
 										<a href="https://github.com/fossasia?utf8=✓&q=meilix" target="_self">Repositories</a>
 									</div>
@@ -340,7 +339,7 @@
 									<p>Susper is a distributed Peer to Peer search engine using Yacy and Elastic Search. The front-end uses Angular JS and Material design.</p><div><br></div><div><br></div>
 									<div class="text-link" style="margin-right: 15%">
 										<a href="http://susper.com" target="_self">Website</a>
-										<a href="https://gitter.im/fossasaia/susper.com" target="_self">Chat</a>
+										<a href="https://gitter.im/fossasia/susper.com" target="_self">Chat</a>
 										<a href="https://groups.google.com/forum/#!forum/opntec-dev" target="_self">Mailing List</a>
 										<a href="https://github.com/fossasia/susper.com" target="_self">Repository</a>
 									</div>
@@ -354,7 +353,7 @@
 									<p>Yaydoc is a documentation generator for Git and GitHub projects generating a complete website with search capabilities and automatic deployment on each merged pull request.</p><div><br></div><div><br></div>
 									<div class="text-link" style="margin-right: 15%">
 										<a href="http://yaydoc.org" target="_self">Website</a>
-										<a href="https://gitter.im/fossasaia/yaydoc" target="_self">Chat</a>
+										<a href="https://gitter.im/fossasia/yaydoc" target="_self">Chat</a>
 										<a href="http://groups.google.com/group/yaydoc/" target="_self">Mailing List</a>
 										<a href="https://github.com/fossasia/yaydoc" target="_self">Repository</a>
 									</div>
@@ -382,7 +381,7 @@
 									<p>FOSSASIA Labs provides a starting point for developers interested in new projects and additional components to existing projects. The issue tracker holds a number of project ideas to get started.</p><div><br></div><div><br></div>
 									<div class="text-link" style="margin-right: 15%">
 										<a href="http://labs.fossasia.org" target="_self">Website</a>
-										<a href="https://gitter.im/fossasaia/fossasia" target="_self">Chat</a>
+										<a href="https://gitter.im/fossasia/fossasia" target="_self">Chat</a>
 										<a href="http://groups.google.com/group/opntec-dev/" target="_self">Mailing List</a>
 										<a href="https://github.com/fossasia/labs.fossasia.org" target="_self">Repository</a>
 									</div>
@@ -396,7 +395,7 @@
 									<p>SUSI.AI modules for Magic Mirror.
 									Apart from the SUSI.AI core repositories in this project we integrate SUSI.AI into the Magic Mirror project. Join us developing the magic mirror!</p><div><br></div><div><br></div>
 									<div class="text-link" style="margin-right: 31%">
-										<a href="https://gitter.im/fossasaia/susi_server" target="_self">Chat</a>
+										<a href="https://gitter.im/fossasia/susi_server" target="_self">Chat</a>
 										<a href="http://groups.google.com/group/susiai/" target="_self">Mailing List</a>
 										<a href="https://github.com/fossasia/MMM-SUSI-AI" target="_self">Repository</a>
 									</div>
@@ -409,7 +408,7 @@
 									<h3>Badgeyay</h3>
 									<p>At every event the same question comes up "how to print out badges". There are a number of proprietary websites out there, by why not create our own automatic badge generator for events?</p><div><br></div><div><br></div>
 									<div class="text-link" style="margin-right: 31%">
-										<a href="https://gitter.im/fossasaia/open-event-orga-server" target="_self">Chat</a>
+										<a href="https://gitter.im/fossasia/open-event-orga-server" target="_self">Chat</a>
 										<a href="http://groups.google.com/group/open-event/" target="_self">Mailing List</a>
 										<a href="https://github.com/fossasia/badgeyay" target="_self">Repository</a>
 									</div>


### PR DESCRIPTION
In the chat link of susper.com and 6 other projects the href was https://www.gitter.im/fossasaia/<project-name>
I rectified it to fossasia from fossasaia