### PR TITLE
Fixed alignment and style issues

### DIFF
--- a/css/theme-sulphur.css
+++ b/css/theme-sulphur.css
@@ -1804,7 +1804,7 @@ p.question {
 .info-box .text-link {
   position: absolute;
   bottom: 12px;
-  right: 0px;
+  left: 0px;
 }
 .text-link a {
   display: inline-block;

--- a/index.html
+++ b/index.html
@@ -267,19 +267,19 @@
 				<div class="row">
 					<div class="col-sm-3">
 						<h2>700+ participants</h2></a><br>
-						<p>
+						<p style="padding-bottom: 50px;">
 							700 registered in the Codeheat contest 2018/19 and learnt how to participate in the FOSSASIA developer community.
 						</p>
 					</div>
 					<div class="col-sm-5">
 						<h2>2000+ merged pull requests</h2><br>
-						<p>
+						<p style="padding-bottom: 50px;">
 							More than 2000 pull requests were merged during last year's contest. Participants also submitted scrum reports, wrote blog posts and created entirely new projects in the FOSSASIA community.
 						</p>
 					</div>
 					<div class="col-sm-4">
 						<a class="inner-link" href="#mentors" target="_self"><h2>35 mentors</h2></a><br>
-						<p>
+						<p style="padding-bottom: 50px;">
 							Mentors are developers, engineers, university students, professors, and generally contributors who love to share and be a part of our open source community. They help creating better software for a better and just world.
 						</p>
 					</div>
@@ -341,7 +341,7 @@
              <span>Developer at FOSSASIA</span>
            </div>
          </div>
-				<div class="col-md-3 col-sm-6 speaker-column">
+		<div class="col-md-3 col-sm-6 col-md-offset-1 speaker-column">
           <div class="speaker">
             <div class="image-holder">
               <img class="background-image" alt="Suneet Srivastava" src="img/SuneetSrivastava.jpeg">


### PR DESCRIPTION
Description :

In the Codeheat website, for mobile view, the info looks like this - 
![Codeheat site alignment-err](https://user-images.githubusercontent.com/48355572/87316779-d4175100-c543-11ea-8429-e1b9e30d3e76.JPG)

Here, this looks very clumsy
![clumsy](https://user-images.githubusercontent.com/48355572/87317413-94049e00-c544-11ea-8f04-0e40c7dd2024.JPG)


So, I fixed the styling to - 
![fixed styling issue info](https://user-images.githubusercontent.com/48355572/87317090-2bb5bc80-c544-11ea-9e6a-bf18f0f05b3a.JPG)

Where, the desktop view remains unaffected
![Desktop view](https://user-images.githubusercontent.com/48355572/87317218-543db680-c544-11ea-8b8d-214c865e1937.JPG)

Also, images in the `Grand Prize Winners` section is not correctly spaced. It looks like this - 
![column alignment prob](https://user-images.githubusercontent.com/48355572/87317655-f198ea80-c544-11ea-8b07-a4823f2915c9.JPG)

So, I adjusted the spacing correctly to -
![corrected spacing alignment](https://user-images.githubusercontent.com/48355572/87317904-40df1b00-c545-11ea-8bda-32405095078c.JPG)

And in responsive view, it doesn't shows any new changes - 
![mobile view correct](https://user-images.githubusercontent.com/48355572/87318128-8996d400-c545-11ea-8d6b-5fc013ade1b7.JPG)

And last but not the least, in the `Participating Projects` section, the tags are not properly aligned. It looks like - 
![tags wrong](https://user-images.githubusercontent.com/48355572/87318398-e85c4d80-c545-11ea-8579-b4e85c2f6cce.JPG)

Thus I edited the alignment to - 
![corrected tags](https://user-images.githubusercontent.com/48355572/87318562-23f71780-c546-11ea-82f2-4cec85bd838e.JPG)


Type of Change:
- [x] Code
- [x] Bug fix (non-breaking change)