### PR TITLE
Fix: Fixed collapse property of menu bar

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -13,6 +13,7 @@ $(document).ready(function() {
     });
 
     $('a').click(function() {
+        $('nav').toggleClass('open-menu');
         if ($(this).attr('href') === '#') {
             return false;
         }


### PR DESCRIPTION

Fixes #250 

Fixed the behavior of the navbar on mobile.

Fixed Behaviour: on selecting an option navbar collapses

# demo

![Screen Recording (29-08-2020 15-54-57)](https://user-images.githubusercontent.com/43727167/91634730-3b179900-ea10-11ea-9d05-c578062e4ade.gif)
