### PR TITLE
Update README with a hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Single commit per pull request
 For writing commit messages please adhere to the Commit style guidelines.
 Follow uniform design practices. The design language must be consistent throughout the app.
 The pull request will not get merged until and unless the commits are squashed. In case there are multiple commits on the PR, the commit author needs to squash them and not the maintainers cherrypicking and merging squashes.
-If you don't know what does squashing of commits is read from here.
+If you don't know what does squashing of commits means, then read it from [here](https://medium.com/@slamflipstrom/a-beginners-guide-to-squashing-commits-with-git-rebase-8185cf6e62ec).
 If the PR is related to any front end change, please attach relevant screenshots in the pull request description
 
 Step 3: Submitting a PR


### PR DESCRIPTION
Initially, it was-
If you don't know what does squashing of commits is read from here.
After Changes-
If you don't know what does squashing of commits means, then read it from [here](https://medium.com/@slamflipstrom/a-beginners-guide-to-squashing-commits-with-git-rebase-8185cf6e62ec).