### PR TITLE
Fixed Mentor section page layout

### DIFF
--- a/css/theme-sulphur.css
+++ b/css/theme-sulphur.css
@@ -1273,6 +1273,11 @@ nav .container {
   display: block;
   font-size: 16px;
 }
+@media all and (max-width:1200px) and (min-width:992px){
+  .speaker span{
+    font-size:13px
+  }
+}
 .speaker-name {
   color: #333333;
 }


### PR DESCRIPTION
The issue was due the text "Jaipur" coming in the next line so alignment of next row was distorted.
[BEFORE]
![Screenshot 2020-09-23 101550](https://user-images.githubusercontent.com/71120226/93968182-a130db00-fd86-11ea-9dc9-b0b75c1293bf.jpg)

So I fixed it by adding a media query to reduce the font-size for width: 992px - 1200px because the problem was coming between these width sizes only.
[AFTER]
![Screen Shot 2020-09-23 at 10 29 30](https://user-images.githubusercontent.com/71120226/93968687-d558cb80-fd87-11ea-8e74-c32931b7868b.png)
