### PR TITLE
Fixed Mentor section Layout

### DIFF
--- a/css/theme-sulphur.css
+++ b/css/theme-sulphur.css
@@ -1273,6 +1273,11 @@ nav .container {
   display: block;
   font-size: 16px;
 }
+@media all and (min-width:992px) and (max-width:1200px){
+  .speaker span{
+    font-size: 13px;
+  }
+}
 .speaker-name {
   color: #333333;
 }


### PR DESCRIPTION
The issue was due the text "Jaipur" coming in the next line so alignment of next row was distorted.
[BEFORE]
![93968182-a130db00-fd86-11ea-9dc9-b0b75c1293bf](https://user-images.githubusercontent.com/71120226/94243296-d24f0e00-ff34-11ea-8146-66631deb1d25.jpg)

So I fixed it by adding a media query to reduce the font-size for width: 992px - 1200px because the problem was coming between these width sizes only.
[AFTER]
![93968687-d558cb80-fd87-11ea-8e74-c32931b7868b](https://user-images.githubusercontent.com/71120226/94243304-d67b2b80-ff34-11ea-8d2b-77252907fcf0.png)
