### PR TITLE
fix: Social link icons is not center while hover (FIXED FOR ALL TYPES OF DEVICES)

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -92,15 +92,3 @@
 .background-image {
   width: 300px;
 }
-@media all and (max-width: 767px) {	
-  .footer .menu {
-  width: 100%;	
-  }
-}
-
-@media screen and (min-width: 922px) and (max-width: 1200px)
-{
-  .vertical-align {
-    right: 9%;
-  }
-}

--- a/css/custom.css
+++ b/css/custom.css
@@ -92,3 +92,15 @@
 .background-image {
   width: 300px;
 }
+@media all and (max-width: 767px) {	
+  .footer .menu {
+  width: 100%;	
+  }
+}
+
+@media screen and (min-width: 922px) and (max-width: 1200px)
+{
+  .vertical-align {
+    right: 9%;
+  }
+}

--- a/css/theme-deepblue.css
+++ b/css/theme-deepblue.css
@@ -30,6 +30,7 @@
   -webkit-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
+  right: 5%;
 }
 .vertical-align-cancel {
   top: 0px;


### PR DESCRIPTION
### descption-
Fixed social link icons is not center while hover see in the screenshot for the better understanding.

### issue-
#290 

### screenshot before-
![bf](https://user-images.githubusercontent.com/65535360/99188210-c2a7b500-2780-11eb-9a26-43cb8daae821.PNG)

### screenshot after-
![afteer](https://user-images.githubusercontent.com/65535360/99188214-c89d9600-2780-11eb-8cf9-112f3450760d.PNG)

