### PR TITLE
Redirecting social media pages to new tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
 								<a href="#about" class="inner-link" target="_self">About</a>
 								<ul class="nav-dropdown">
 									<li>
-										<a href="https://fossasia.org" target="_self">FOSSASIA.org</a>
+										<a href="https://fossasia.org" target="_blank">FOSSASIA.org</a>
 									</li>
 									<li>
 										<a href="https://2019.codeheat.org" target="_self">Codeheat 2019</a>
@@ -118,7 +118,7 @@
 								<a href="#projects" class="inner-link" target="self">Projects</a>
 								<ul class="nav-dropdown" style="min-height:300px">
 									<li>
-										<a href="https://github.com/fossasia" target="_self">FOSSASIA Github</a>
+										<a href="https://github.com/fossasia" target="_blank">FOSSASIA Github</a>
 									</li>
 									<li>
 										<a href="https://github.com/search?l=&o=desc&q=org%3Afossasia+org%3Avoicerepublic+label%3Acodeheat+state%3Aopen&s=created&type=Issues
@@ -154,12 +154,12 @@
 								<a class="inner-link" href="http://blog.fossasia.org/tag/codeheat/" target="_self">Blog</a>
 							</li>
 							<li class="social-link">
-								<a href="https://twitter.com/codeheat_" target="_self">
+								<a href="https://twitter.com/codeheat_" target="_blank">
 									<i class="icon social_twitter"></i>
 								</a>
 							</li>
 							<li class="social-link">
-								<a href="https://www.facebook.com/codeheat.org/" target="_self">
+								<a href="https://www.facebook.com/codeheat.org/" target="_blank">
 									<i class="icon social_facebook"></i>
 								</a>
 							</li>


### PR DESCRIPTION
I have converted "_self" to "_blank" I guess it would be better if the social media pages and the main github page loads on a new tab so that visitors do not loose the track of our page.