### PR TITLE
updated targets to "_blank" for jury and mentors section Issue #319

### DIFF
--- a/index.html
+++ b/index.html
@@ -861,19 +861,19 @@
 									<img class="background-image" alt="Mario Behling" src="img/mariobehling.jpg">
 									<div class="hover-state text-center preserve3d">
 										<div class="social-links vertical-align">
-											<a href="https://opntec.com">
+											<a href="https://opntec.com"  target="_blank">
                                                <i class="icon fa fa-external-link"></i>
                                             </a>
-											<a href="https://mariobehling.com">
+											<a href="https://mariobehling.com"  target="_blank">
                                                <i class="icon fa fa-external-link"></i>
                                             </a>
-											<a href="https://github.com/mariobehling">
+											<a href="https://github.com/mariobehling" target="_blank">
 												<i class="icon fa fa-github"></i>
 											</a>
-											<a href="https://twitter.com/mariobehling" target="default">
+											<a href="https://twitter.com/mariobehling" target="_blank">
 												<i class="icon social_twitter"></i>
 											</a>
-											<a href="https://www.linkedin.com/in/mariobehling" target="_self">
+											<a href="https://www.linkedin.com/in/mariobehling" target="_blank">
 												<i class="icon social_linkedin"></i>
 											</a>
 										</div>
@@ -895,16 +895,16 @@
 									<img class="background-image" alt="Hong Phuc Dang" src="img/hongphucdang.jpg">
 									<div class="hover-state text-center preserve3d">
 										<div class="social-links vertical-align">
-											<a href="https://github.com/hpdang">
+											<a href="https://github.com/hpdang" target="_blank">
 												<i class="icon fa fa-github"></i>
 											</a>
-											<a href="https://twitter.com/hpdang" target="_self">
+											<a href="https://twitter.com/hpdang" target="_blank">
 												<i class="icon social_twitter"></i>
 											</a>
-											<a href="https://www.facebook.com/hpdang">
+											<a href="https://www.facebook.com/hpdang" target="_blank">
 												<i class="icon social_facebook"></i>
 											</a>
-											<a href="https://www.linkedin.com/in/hongphucdang" target="_self">
+											<a href="https://www.linkedin.com/in/hongphucdang" target="_blank">
 												<i class="icon social_linkedin"></i>
 											</a>
 										</div>
@@ -960,10 +960,10 @@
 											<a href="https://github.com/Orbiter">
 												<i class="icon fa fa-github"></i>
 											</a>
-											<a href="https://twitter.com/0rb1t3r" target="_self">
+											<a href="https://twitter.com/0rb1t3r" target="_blank">
 												<i class="icon social_twitter"></i>
 											</a>
-											<a href="https://www.linkedin.com/in/orbiter" target="_self">
+											<a href="https://www.linkedin.com/in/orbiter" target="_blank">
 												<i class="icon social_linkedin"></i>
 											</a>
 										</div>
@@ -985,16 +985,16 @@
 									<div class="hover-state text-center preserve3d">
 										<div class="social-links vertical-align">
                                             </a>
-											<a href="https://github.com/iamareebjamal">
+											<a href="https://github.com/iamareebjamal" target="_blank">
 												<i class="icon fa fa-github"></i>
 											</a>
-											<a href="https://facebook.com/iamareebjamal">
+											<a href="https://facebook.com/iamareebjamal" target="_blank">
 												<i class="icon social_facebook"></i>
 											</a>
-											<a href="https://twitter.com/iamareebjamal">
+											<a href="https://twitter.com/iamareebjamal" target="_blank">
 												<i class="icon social_twitter"></i>
 											</a>
-											<a href="https://www.linkedin.com/in/iamareebjamal/">
+											<a href="https://www.linkedin.com/in/iamareebjamal/" target="_blank">
 												<i class="icon social_linkedin"></i>
 										</a>
 										</div>
@@ -1015,16 +1015,16 @@
 									<img class="background-image" alt="Quan Nguyen" src="img/QuanNguyen.jpg">
 									<div class="hover-state text-center preserve3d">
 										<div class="social-links vertical-align">
-										<a href="https://github.com/hongquan/">
+										<a href="https://github.com/hongquan/" target="_blank">
 											<i class="icon fa fa-github"></i>
 										</a>
-										<a href="https://www.facebook.com/ng.hong.quan">
+										<a href="https://www.facebook.com/ng.hong.quan" target="_blank">
 											<i class="icon social_facebook"></i>
 										</a>
-										<a href="https://twitter.com/ng_hongquan">
+										<a href="https://twitter.com/ng_hongquan" target="_blank">
 											<i class="icon social_twitter"></i>
 										</a>
-										<a href="https://linkedin.com/in/bachkhois">
+										<a href="https://linkedin.com/in/bachkhois" target="_blank">
 											<i class="icon social_linkedin"></i>
 										</a>
 										</div>
@@ -1070,10 +1070,10 @@
 								<img class="background-image" alt="Eden Dang" src="img/EdenDang.jpeg">
 								<div class="hover-state text-center preserve3d">
 									<div class="social-links vertical-align">
-										<a href="https://github.com/edenyay">
+										<a href="https://github.com/edenyay" target="_blank">
 											<i class="icon fa fa-github"></i>
 										</a>
-										<a href="https://twitter.com/edenyay">
+										<a href="https://twitter.com/edenyay" target="_blank">
 											<i class="icon social_twitter"></i>
 										</a>
 									</div>
@@ -1090,16 +1090,16 @@
 								<img class="background-image" alt="Akshat Garg" src="img/akshatnitd.jpeg">
 								<div class="hover-state text-center preserve3d">
 									<div class="social-links vertical-align">
-										<a href="https://github.com/akshatnitd">
+										<a href="https://github.com/akshatnitd" target="_blank">
 											<i class="icon fa fa-github"></i>
 										</a>
-										<a href="https://www.facebook.com/akshatnitd">
+										<a href="https://www.facebook.com/akshatnitd" target="_blank">
 											<i class="icon social_facebook"></i>
 										</a>
-										<a href="https://twitter.com/tweet_akshat">
+										<a href="https://twitter.com/tweet_akshat" target="_blank">
 											<i class="icon social_twitter"></i>
 										</a>
-										<a href="https://www.linkedin.com/in/akshatnitd/">
+										<a href="https://www.linkedin.com/in/akshatnitd/" target="_blank">
 											<i class="icon social_linkedin"></i>
 										</a>
 									</div>
@@ -1116,10 +1116,10 @@
 								<img class="background-image" alt="Lorenz Gerber" src="img/LorenzGerber.jpg">
 								<div class="hover-state text-center preserve3d">
 									<div class="social-links vertical-align">
-										<a href="https://github.com/lorenzgerber">
+										<a href="https://github.com/lorenzgerber" target="_blank">
 											<i class="icon fa fa-github"></i>
 										</a>
-										<a href="https://twitter.com/GerberLorenz">
+										<a href="https://twitter.com/GerberLorenz" target="_blank">
 											<i class="icon social_twitter"></i>
 										</a>
 									</div>
@@ -1136,13 +1136,13 @@
 								<img class="background-image" alt="Isuru Abeywardana" src="img/isuruAb.jpg">
 								<div class="hover-state text-center preserve3d">
 									<div class="social-links vertical-align">
-										<a href="https://github.com/isuruAb">
+										<a href="https://github.com/isuruAb" target="_blank">
 											<i class="icon fa fa-github"></i>
 										</a>
-										<a href="https://twitter.com/isuruAb">
+										<a href="https://twitter.com/isuruAb" target="_blank">
 											<i class="icon social_twitter"></i>
 										</a>
-										<a href="https://www.linkedin.com/in/isuruab/">
+										<a href="https://www.linkedin.com/in/isuruab/" target="_blank">
 											<i class="icon social_linkedin"></i>
 										</a>
 									</div>
@@ -1159,16 +1159,16 @@
 								<img class="background-image" alt="Sanskar Jethi" src="img/SanskarJethi.jpg">
 								<div class="hover-state text-center preserve3d">
 									<div class="social-links vertical-align">
-										<a href="https://github.com/stealthanthrax">
+										<a href="https://github.com/stealthanthrax" target="_blank">
 											<i class="icon fa fa-github"></i>
 										</a>
-										<a href="https://www.facebook.com/sanskar.jethi">
+										<a href="https://www.facebook.com/sanskar.jethi" target="_blank">
 											<i class="icon social_facebook"></i>
 										</a>
-										<a href="https://twitter.com/sansyrox">
+										<a href="https://twitter.com/sansyrox" target="_blank">
 											<i class="icon social_twitter"></i>
 										</a>
-										<a href="https://www.linkedin.com/in/sanskar123">
+										<a href="https://www.linkedin.com/in/sanskar123" target="_blank">
 											<i class="icon social_linkedin"></i>
 										</a>
 									</div>
@@ -1185,16 +1185,16 @@
 								<img class="background-image" alt="Harshit Khandelwal" src="img/liveHarshit.jpg">
 								<div class="hover-state text-center preserve3d">
 									<div class="social-links vertical-align">
-										<a href="https://github.com/liveHarshit" target="blank">
+										<a href="https://github.com/liveHarshit" target="_blank">
 											<i class="icon fa fa-github"></i>
 										</a>
-										<a href="https://www.linkedin.com/in/liveharshit/" target="blank">
+										<a href="https://www.linkedin.com/in/liveharshit/" target="_blank">
 											<i class="icon social_linkedin"></i>
 										</a>
-										<a href="https://twitter.com/liveHarshit26" target="blank">
+										<a href="https://twitter.com/liveHarshit26" target="_blank">
 											<i class="icon social_twitter"></i>
 										</a>
-										<a href="https://www.facebook.com/live.harshit26" target="blank">
+										<a href="https://www.facebook.com/live.harshit26" target="_blank">
 											<i class="icon social_facebook"></i>
 										</a>
 									</div>
@@ -1211,19 +1211,19 @@
 								<img class="background-image" alt="Norbert Preining" src="img/NorbertPreining.jpg">
 								<div class="hover-state text-center preserve3d">
 									<div class="social-links vertical-align">
-											<a href="https://www.preining.info">
+											<a href="https://www.preining.info" target="_blank">
                                                <i class="icon fa fa-external-link"></i>
                                             </a>
-											<a href="https://github.com/norbusan">
+											<a href="https://github.com/norbusan" target="_blank">
 												<i class="icon fa fa-github"></i>
 											</a>
-											<a href="https://twitter.com/norbusan" target="_self">
+											<a href="https://twitter.com/norbusan" target="_blank">
 												<i class="icon social_twitter"></i>
 											</a>
-											<a href="https://www.facebook.com/norbert.preining">
+											<a href="https://www.facebook.com/norbert.preining" target="_blank">
 												<i class="icon social_facebook"></i>
 											</a>
-											<a href="https://www.linkedin.com/in/norbertpreining" target="_self">
+											<a href="https://www.linkedin.com/in/norbertpreining" target="_blank">
 												<i class="icon social_linkedin"></i>
 											</a>
 									</div>
@@ -1240,10 +1240,10 @@
 								<img class="background-image" alt="Rafael Lee" src="img/RafaelLee.jpg">
 								<div class="hover-state text-center preserve3d">
 									<div class="social-links vertical-align">
-											<a href="https://www.preining.info">
+											<a href="https://www.preining.info" target="_blank">
                                                <i class="icon fa fa-external-link"></i>
                                             </a>
-											<a href="https://github.com/RafaelLeeImg">
+											<a href="https://github.com/RafaelLeeImg" target="_blank">
 												<i class="icon fa fa-github"></i>
 											</a>
 											</a>
@@ -1261,19 +1261,19 @@
 								<img class="background-image" alt="Prateek Jain" src="img/PrateekJain.jpeg">
 								<div class="hover-state text-center preserve3d">
 									<div class="social-links vertical-align">
-										<a href="https://www.prateekj117.me">
+										<a href="https://www.prateekj117.me" target="_blank">
 											<i class="icon fa fa-external-link"></i>
 										</a>
-										<a href="https://github.com/prateekj117">
+										<a href="https://github.com/prateekj117" target="_blank">
 											<i class="icon fa fa-github"></i>
 										</a>
-										<a href="https://twitter.com/prateekj117" target="_self">
+										<a href="https://twitter.com/prateekj117" target="_blank">
 											<i class="icon social_twitter"></i>
 										</a>
-										<a href="https://www.facebook.com/prateekj117">
+										<a href="https://www.facebook.com/prateekj117" target="_blank">
 											<i class="icon social_facebook"></i>
 										</a>
-										<a href="https://www.linkedin.com/in/prateekj117" target="_self">
+										<a href="https://www.linkedin.com/in/prateekj117" target="_blank">
 											<i class="icon social_linkedin"></i>
 										</a>
 									</div>
@@ -1293,13 +1293,13 @@
 										<a href="https://github.com/codedsun">
 											<i class="icon fa fa-github"></i>
 										</a>
-										<a href="https://twitter.com/dSuneetSri" target="_self">
+										<a href="https://twitter.com/dSuneetSri" target="_blank">
 											<i class="icon social_twitter"></i>
 										</a>
-										<a href="https://www.facebook.com/dSuneetSri">
+										<a href="https://www.facebook.com/dSuneetSri" target="_blank">
 											<i class="icon social_facebook"></i>
 										</a>
-										<a href="https://www.linkedin.com/in/codedsun" target="_self">
+										<a href="https://www.linkedin.com/in/codedsun" target="_blank">
 											<i class="icon social_linkedin"></i>
 										</a>
 									</div>
@@ -1316,10 +1316,10 @@
 								<img class="background-image" alt="Saptak Sengupta" src="img/SaptakSengupta.jpg">
 								<div class="hover-state text-center preserve3d">
 									<div class="social-links vertical-align">
-											<a href="https://saptaks.website/">
+											<a href="https://saptaks.website/" target="_blank">
                                                <i class="icon fa fa-external-link"></i>
                                             </a>
-											<a href="https://github.com/saptaks">
+											<a href="https://github.com/saptaks" target="_blank">
 												<i class="icon fa fa-github"></i>
 											</a>
 											</a>
@@ -1337,10 +1337,10 @@
 								<img class="background-image" alt="Ambrose Chua" src="img/AmbroseChua.jpg">
 								<div class="hover-state text-center preserve3d">
 									<div class="social-links vertical-align">
-											<a href="https://ambrose.website/">
+											<a href="https://ambrose.website/" target="_blank">
                                                <i class="icon fa fa-external-link"></i>
                                             </a>
-											<a href="https://github.com/serverwentdown">
+											<a href="https://github.com/serverwentdown" target="_blank">
 												<i class="icon fa fa-github"></i>
 											</a>
 											</a>
@@ -1358,10 +1358,10 @@
 								<img class="background-image" alt="Mishari Muqbil" src="img/MishariMuqbil.jpeg">
 								<div class="hover-state text-center preserve3d">
 									<div class="social-links vertical-align">
-											<a href="https://www.mishari.net/about/">
+											<a href="https://www.mishari.net/about/" target="_blank">
                                                <i class="icon fa fa-external-link"></i>
                                             </a>
-											<a href="https://github.com/mishari">
+											<a href="https://github.com/mishari" target="_blank">
 												<i class="icon fa fa-github"></i>
 											</a>
 											</a>
@@ -1379,10 +1379,10 @@
 								<img class="background-image" alt="Bella Phan" src="img/BellaPhan.jpeg">
 								<div class="hover-state text-center preserve3d">
 									<div class="social-links vertical-align">
-										<a href="https://github.com/bellaphan/">
+										<a href="https://github.com/bellaphan/" target="_blank">
 											<i class="icon fa fa-github"></i>
 										</a>
-										<a href="https://twitter.com/bellaphan2211">
+										<a href="https://twitter.com/bellaphan2211" target="_blank">
 											<i class="icon social_twitter"></i>
 										</a>
 									</div>


### PR DESCRIPTION
**updated inconsistent anchor targets**

updated `<a />` tag `target` to `target = "_blank"` 
for all social links in **Jury** and **Mentors** section.

for issue #319 