### PR TITLE
updated all codeheat contest date from 2021 to 2023

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,7 +190,7 @@
 					</div>
 
 					<div class="copy-text">
-						<span>© Copyright 2021 FOSSASIA</span>
+						<span>© Copyright 2023 FOSSASIA</span>
 					</div>
 				</div>
 			</div>
@@ -336,7 +336,7 @@
 					<div class="row">
 						<div class="col-sm-offset- col-sm-11">
 							<h1 class="text-white">Codeheat Issues</h1>
-							<p class="lead text-white">FOSSASIA and OpnTec run the <a href="https://codeheat.org" target="_self">Codeheat</a> coding contest from November 10, 2021 to May 11, 2022. Codeheat is separated into two month periods. After each period we announce winners of the period. Participants contributing at least five pull requests can get a digital certificate and with more than ten pull requests developers can win awesome prizes. Eligible issues for the contest have  <a href="https://github.com/search?l=&o=desc&q=org%3Afossasia+label%3Acodeheat+state%3Aopen&s=created&type=Issues" target="_self">the label "Codeheat" on GitHub</a>. Please join the <a href="https://orgmanager.herokuapp.com/o/fossasia">FOSSASIA GitHub organization</a> and get started.</p>
+							<p class="lead text-white">FOSSASIA and OpnTec run the <a href="https://codeheat.org" target="_self">Codeheat</a> coding contest from December 1, 2023 to March 31, 2024. Codeheat is separated into two month periods. After each period we announce winners of the period. Participants contributing at least five pull requests can get a digital certificate and with more than ten pull requests developers can win awesome prizes. Eligible issues for the contest have  <a href="https://github.com/search?l=&o=desc&q=org%3Afossasia+label%3Acodeheat+state%3Aopen&s=created&type=Issues" target="_self">the label "Codeheat" on GitHub</a>. Please join the <a href="https://orgmanager.herokuapp.com/o/fossasia">FOSSASIA GitHub organization</a> and get started.</p>
 						</div>
 					</div>
 				</div>
@@ -673,11 +673,11 @@
 							Codeheat is a coding contest for
 							<a href="https://github.com/search?l=&o=desc&q=org%3Afossasia+label%3Acodeheat+state%3Aopen&s=created&type=Issues" target="_self">FOSSASIA projects on GitHub</a>.
 							<br>
-							<br> The contest runs until May 11, 2022. The contest is separated into two months period after which winners of each period are announced.
+							<br> The contest runs until March 31, 2024. The contest is separated into two months period after which winners of each period are announced.
 							<br>
 							<br> Our jury will choose the winners from the top 10 contributors according to code quality and relevance of commits for the project each period. The jury also takes other contributions like submitted scrum reports and technical blog posts into account, but of course awesome code is the most important item on the list.
 							<br>
-							<br> Other participants will have the chance to win Tshirts and Swag and will get certificates of participation. These will be provided after the end of the contest on May 11, 2022.
+							<br> Other participants will have the chance to win Tshirts and Swag and will get certificates of participation. These will be provided after the end of the contest on March 31, 2024.
 							<a href="./register" target="_self">Sign up here now</a>
 						</p>
 					</div>
@@ -1989,7 +1989,7 @@
 						</p>
 
 						<p>
-							Everyone who gets five pull requests merged during the entire contest (November 2020 - May 2021) will receive a digital certificate of participation from the FOSSASIA organization. Developers with 10 merged PRs or more in the contest will receive a Tshirt or other cool items from FOSSASIA (if postal distribution is feasible).
+							Everyone who gets five pull requests merged during the entire contest (December 2023 - March 2024) will receive a digital certificate of participation from the FOSSASIA organization. Developers with 10 merged PRs or more in the contest will receive a Tshirt or other cool items from FOSSASIA (if postal distribution is feasible).
 							<br> Out of the top ten contributors in each contest period three grand prize winners will be chosen by the jury. The grand prize winners will receive a 100 SGD cash prize as a token of appreciation. Plus, they will have the chance to present their work at the Codeheat online event. An additional three finalists will receive a 50 SGD appreciation token.</p>
 					</div>
 				</div>
@@ -2054,7 +2054,7 @@
 							When does the contest begin? Can I join the contest at any time?</p>
 
 						<p>
-							The contest begins at 9:00 AM (SGT/GMT+8) on November 10, 2021 and runs until 11:00 PM (SGT/GMT+8) on May 11, 2022. Participants should take the time to read through the contest website and familiarize themselves with the introductory information and Readme.md of the project before starting to work on an issue. Interested developers can join the contest at any time during the program.
+							The contest begins at 9:00 AM (SGT/GMT+8) on December 1, 2023 and runs until 11:00 PM (SGT/GMT+8) on March 31, 2024. Participants should take the time to read through the contest website and familiarize themselves with the introductory information and Readme.md of the project before starting to work on an issue. Interested developers can join the contest at any time during the program.
 							<br>
 
 						</p>
@@ -2295,7 +2295,7 @@
 			<div class="container">
 				<div class="row ui-sortable">
 					<div class="col-sm-3">
-						<span class="text-white">© Copyright 2021 Creative Commons By License. FOSSASIA CodeHeat.</span>
+						<span class="text-white">© Copyright 2023 Creative Commons By License. FOSSASIA CodeHeat.</span>
 					</div>
 
 					<div class="col-sm-9 text-right">


### PR DESCRIPTION
New timeline of codeheat contest 2023-2024 was added to website, but still, in many places contest date was not updated. So, I updated it based on new timeline of 2023-2024 contest. Thank you. 